### PR TITLE
wrap checking backends in a try, except block. otherwise we'll choke on python-social-auth backends

### DIFF
--- a/loginas/views.py
+++ b/loginas/views.py
@@ -54,9 +54,14 @@ def user_login(request, user_id):
     # Find a suitable backend.
     if not hasattr(user, 'backend'):
         for backend in settings.AUTHENTICATION_BACKENDS:
-            if user == load_backend(backend).get_user(user.pk):
-                user.backend = backend
-                break
+            try:
+                if user == load_backend(backend).get_user(user.pk):
+                    user.backend = backend
+                    break
+            except:
+                continue
+
+
 
     # Log the user in.
     if hasattr(user, 'backend'):


### PR DESCRIPTION
Not sure if this creates other side-effects. But I was having an issue with django-loginas with python-social-auth and this fixed it! Hope it's helpful!

Just ran the tests--they pass still.