### PR TITLE
Use import_module from stdlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,9 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
 install: "pip install Django==$DJANGO_VERSION --use-mirrors"
 script: loginas/tests/manage.py test --verbosity=2 tests
 env:
-  - DJANGO_VERSION=1.4.16
-  - DJANGO_VERSION=1.5.11
-  - DJANGO_VERSION=1.6.8
-  - DJANGO_VERSION=1.7.1
-
-matrix:
-  exclude:
-   - python: 3.3
-     env: DJANGO_VERSION=1.4.16
-   - python: 2.6
-     env: DJANGO_VERSION=1.7.1
+  - DJANGO_VERSION=1.7.10
+  - DJANGO_VERSION=1.8.6

--- a/loginas/views.py
+++ b/loginas/views.py
@@ -1,9 +1,10 @@
+from importlib import import_module
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import load_backend, login
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import redirect
-from django.utils.importlib import import_module
 from django.utils import six
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py27-1.7,py35,py35-1.7
+envlist=py27,py27-1.7,py34,py34-1.7
 
 [testenv]
 deps=
@@ -16,12 +16,12 @@ basepython=python2.7
 deps=
     django==1.7.10
 
-[testenv:py35]
-basepython=python3.5
+[testenv:py34]
+basepython=python3.4
 deps=
     django==1.8.6
 
-[testenv:py35-1.7]
-basepython=python3.5
+[testenv:py34-1.7]
+basepython=python3.4
 deps=
     django==1.7.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,32 +1,27 @@
 [tox]
-envlist=py26-1.4,py26,py27-1.4,py27,py33
+envlist=py27,py27-1.7,py35,py35-1.7
 
 [testenv]
 deps=
-    django==1.5.1
+    django==1.8.6
 commands=python loginas/tests/manage.py test tests --verbosity=2
-
-[testenv:py26-1.4]
-basepython=python2.6
-deps=
-    django==1.4.5
-
-[testenv:py26]
-basepython=python2.6
-deps=
-    django==1.5.1
-
-[testenv:py27-1.4]
-basepython=python2.7
-deps=
-    django==1.4.5
 
 [testenv:py27]
 basepython=python2.7
 deps=
-    django==1.5.1
+    django==1.8.6
 
-[testenv:py33]
-basepython=python3.3
+[testenv:py27-1.7]
+basepython=python2.7
 deps=
-    django==1.5.1
+    django==1.7.10
+
+[testenv:py35]
+basepython=python3.5
+deps=
+    django==1.8.6
+
+[testenv:py35-1.7]
+basepython=python3.5
+deps=
+    django==1.7.10


### PR DESCRIPTION
django.utils.importlib is deprecated and will be removed in Django 1.9

This will break compatibility with Python < 2.7, but Python 2.7 is the minimum version for any supported version of Django.