### PR TITLE
Django 1.4 fixes

### DIFF
--- a/loginas/templates/loginas/change_form.html
+++ b/loginas/templates/loginas/change_form.html
@@ -1,4 +1,5 @@
 {% extends "admin/change_form.html" %}
+{% load url from future %}
 
 {% block object-tools-items %}
     {{ block.super }}

--- a/loginas/utils.py
+++ b/loginas/utils.py
@@ -1,8 +1,7 @@
 import logging
 
 from django.conf import settings as django_settings
-from django.contrib.auth.models import User
-from django.contrib.auth import get_user_model, load_backend, login, logout
+from django.contrib.auth import load_backend, login, logout
 from django.contrib import messages
 from django.core.signing import TimestampSigner, SignatureExpired
 from datetime import timedelta
@@ -13,6 +12,11 @@ signer = TimestampSigner()
 
 logger = logging.getLogger(__name__)
 
+try:
+    from django.contrib.auth import get_user_model
+    User = get_user_model()
+except ImportError:
+    from django.contrib.auth.models import User
 
 def login_as(user, request, store_original_user=True):
     """
@@ -24,7 +28,10 @@ def login_as(user, request, store_original_user=True):
     original_user_pk = request.user.pk
 
     # Get username field's name
-    username_field = get_user_model().USERNAME_FIELD
+    try:
+        username_field = User.USERNAME_FIELD
+    except AttributeError:
+        username_field = 'username'
 
     # Find a suitable backend.
     if not hasattr(user, 'backend'):


### PR DESCRIPTION
The biggest change is catching the case where `get_user_model` is loaded - if that doesn't work, then it imports `User`. This is already being done in `views.py`, this change follows suit.

If `User.USERNAME_FIELD` isn't specified, it defaults to `'username'`.

For the template, Django < 1.5 throws a `NoReverseMatch` exception if that first argument to `url` is in quotes. Doing `load url from future` should fix it without breaking >1.5, however I think it will throw warnings in more recent versions. Perhaps there's a better way to address this?