### PR TITLE
Fix travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 2.7
   - 3.4
-install: "pip install Django==$DJANGO_VERSION --use-mirrors"
+install: "pip install Django==$DJANGO_VERSION"
 script: loginas/tests/manage.py test --verbosity=2 tests
 env:
   - DJANGO_VERSION=1.8


### PR DESCRIPTION
Not sure why this repo has both Travis and Circle? It seems that Circle uses tox and should be superior, hence the Travis file can be removed?